### PR TITLE
Bump TB max version to 141

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,7 +4,7 @@
     "gecko": {
       "id": "minimizeonclose@rsjtdrjgfuzkfg.com",
       "strict_min_version": "128.0",
-      "strict_max_version": "140.*"
+      "strict_max_version": "141.*"
     }
   },
   "name": "Minimize on Close",


### PR DESCRIPTION
I tested with Thunderbird beta 141.0b3 (flatpak), works without any issues so I bumped the supported max version to reflect that.

<img width="761" height="777" alt="image" src="https://github.com/user-attachments/assets/d57ec68f-f0d9-47f2-9078-69e03630c169" />

Thanks for the add-on! :)