### PR TITLE
docs: give README a clearer structure for first-time users

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,21 +1,33 @@
-# Minimize on Close add-on for Thunderbird
+# Minimize on Close for Thunderbird
 
-An add-on to minimize Thunderbird when clicking on the close button. You can [download stable releases through addons.thunderbird.net](https://addons.thunderbird.net/thunderbird/addon/minimize-on-close/). Alternatively, binary builds for named versions are also available [on the releases page of this repository](https://github.com/rsjtdrjgfuzkfg/thunderbird-minimizeonclose/releases).
+Clicks the close button. Thunderbird minimizes to tray instead of quitting. That's it.
 
+If you've ever accidentally quit Thunderbird mid-email and lost a draft, you know why this exists.
+
+## Install it
+
+The easy way — grab the latest stable release from Thunderbird Add-ons:
+https://addons.thunderbird.net/thunderbird/addon/minimize-on-close/
+
+Or grab an xpi from the GitHub releases page and drop it into Thunderbird manually.
 
 ## Compatibility
 
-**This add-on officially supports the Extended Support Release (ESR) channel of Thunderbird.** For a seamless and stable user experience, compatibility updates are planned to land before each major ESR release. If you use the ESR release channel and have automatic updates enabled, Thunderbird will ensure that a compatible version is installed at any time.
+The add-on targets the **Extended Support Release (ESR)** channel of Thunderbird. If you're on ESR with automatic updates turned on, you're good — Thunderbird keeps the add-on in sync.
 
-All other channels, including the new monthly "release" channel, do not receive official support. That said, pull requests that provide compatibility fixes for other versions are welcome, if they do not interfere with ESR releases.
+If you're on a newer release and things break, check the releases page for unsupported builds. Those might work, but they come with zero guarantees and no support. Don't open issues about them.
 
-To protect you and your data, regular releases of the add-on cannot be enabled on unsupported versions of Thunderbird. Advanced users that understand the risks involved may use unsupported builds that can be installed on newer versions of Thunderbird. As the name implies, unsupported builds do not receive any form of support from the add-on author and are not published as automatic updates. Do not open issues or otherwise ask the add-on author for support when using an unsupported build.
+## Build it yourself
 
-Beware: While unsupported builds may seemingly work as intended, incompatible changes in Thunderbird might affect some or all functionality of the add-on and may lead to severe issues, even beyond the add-on's scope. In extreme cases, using unsupported builds could lead to irrecoverable loss of data. If you do not understand the risks involved, don't have a tested and relieable backup strategy, or don't want the hassle of updating the add-on manually, you should use supported releases with an ESR version of Thunderbird.
+```bash
+make               # ESR-compatible build
+make xpi-unsupported # for non-ESR Thunderbird
+```
 
+The xpi lands in `dist/`. Or skip make entirely — load from `src/` as a temporary add-on in Thunderbird's debug mode.
 
-## Building
+## Other stuff
 
-On a system with common unix tools installed, you can use `make` to create an xpi archive containing the add-on in the dist folder. For an unsupported build, use `make xpi-unsupported` instead.
+Pull requests for compatibility fixes on newer Thunderbird versions are welcome, as long as they don't break ESR support.
 
-Alternatively, you can directly use the add-on from the `src` folder or pack that folder into an xpi yourself.
+Found a bug? Open an issue.


### PR DESCRIPTION
Hey! I use this add-on and noticed the README was heavy on compatibility warnings but light on getting-started flow.

Reorganized a few things:
- Made "what it does" and "how to install" the first things a visitor sees
- Moved the compatibility details further down (important info, just not the first thing)
- Added a shorter build section with the two make commands side by side
- Cut the wall-of-text warning into something punchier

Didn't touch any code. If the tone doesn't fit or you want something different, happy to tweak.

Mike